### PR TITLE
fix & add option to define target radius of backmapping

### DIFF
--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -414,7 +414,7 @@ class SolarMACH():
             arrow_dist = min([self.max_dist/3.2, 2.])
             # ref_arr = plt.arrow(alpha_ref[0], 0.01, 0, arrow_dist, head_width=0.2, head_length=0.07, edgecolor='black',
             #                     facecolor='black', lw=1.8, zorder=5, overhang=0.2)
-            ref_arr = plt.arrow(delta_ref, 0.01, 0, arrow_dist, head_width=0.2, head_length=0.07, edgecolor='black',
+            ref_arr = plt.arrow(np.deg2rad(delta_ref), 0.01, 0, arrow_dist, head_width=0.2, head_length=0.07, edgecolor='black',
                                 facecolor='black', lw=1.8, zorder=5, overhang=0.2)
 
             if plot_spirals:

--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -406,7 +406,7 @@ class SolarMACH():
 
             # old eq. for alpha_ref contained redundant dist_e variable:
             # alpha_ref = np.deg2rad(delta_ref) + omega_ref / (reference_vsw / AU) * (dist_e / AU - r) - (omega_ref / (reference_vsw / AU) * (dist_e / AU))
-            alpha_ref = np.deg2rad(delta_ref) + omega_ref / (reference_vsw / AU) * (0 - r)  # TODO: replace 0 with r of source surface (or photosphere)
+            alpha_ref = np.deg2rad(delta_ref) + omega_ref / (reference_vsw / AU) * (aconst.R_sun.to(u.km).value - r)
             # old arrow style:
             # arrow_dist = min([self.max_dist + 0.1, 2.])
             # ref_arr = plt.arrow(alpha_ref[0], 0.01, 0, arrow_dist, head_width=0.12, head_length=0.11, edgecolor='black',

--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -412,7 +412,9 @@ class SolarMACH():
             # ref_arr = plt.arrow(alpha_ref[0], 0.01, 0, arrow_dist, head_width=0.12, head_length=0.11, edgecolor='black',
             #                     facecolor='black', lw=2, zorder=5, overhang=0.2)
             arrow_dist = min([self.max_dist/3.2, 2.])
-            ref_arr = plt.arrow(alpha_ref[0], 0.01, 0, arrow_dist, head_width=0.2, head_length=0.07, edgecolor='black',
+            # ref_arr = plt.arrow(alpha_ref[0], 0.01, 0, arrow_dist, head_width=0.2, head_length=0.07, edgecolor='black',
+            #                     facecolor='black', lw=1.8, zorder=5, overhang=0.2)
+            ref_arr = plt.arrow(delta_ref, 0.01, 0, arrow_dist, head_width=0.2, head_length=0.07, edgecolor='black',
                                 facecolor='black', lw=1.8, zorder=5, overhang=0.2)
 
             if plot_spirals:

--- a/solarmach/tests/test.py
+++ b/solarmach/tests/test.py
@@ -28,7 +28,7 @@ def test_solarmach_initialize():
     assert sm.coord_table.shape == (1, 11)
 
     assert np.round(sm.coord_table['Longitudinal separation between body and reference_long'][0], 1) == -39.9
-    assert np.round(sm.coord_table["Longitudinal separation between body's mangetic footpoint and reference_long"][0], 2) == 20.09
+    assert np.round(sm.coord_table["Longitudinal separation between body's mangetic footpoint and reference_long"][0], 2) == 19.8
 
     # verify backwards compatibility: undefined coord_sys is interpreted as 'Carrington'
     assert sm.coord_sys == 'Carrington'


### PR DESCRIPTION
Before, the magnetic footpoint at the Sun had been calculated for a radial distance of zero, which is unphysical (though it doesn't make a big difference in the outcome). Now introduced is an (hidden) option to define to which radial distance (in solar radii) the backmapping should be carried out:

``` python
sm = SolarMACH(date, bodies, vsw, ref_long, ref_lat, coord_sys, target_solar_radius=2.5)
```
This is by default `1`, so the radius of the Sun. Setting it to 0 provides the behaviour so far; 2.5 would correspond to the standard source surface in a PFSS model.