### PR TITLE
Use sunpy.time.parse_time for all datetimes

### DIFF
--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -142,12 +142,11 @@ def get_sw_speed(body, dtime, trange=1, default_vsw=400.0):
         print(f"Body '{body}' not supported, assuming default Vsw value of {default_vsw} km/s.")
         return default_vsw
 
-    if type(dtime) == str:
-        try:
-            dtime = parse_time(dtime).datetime  # dateutil.parser.parse(dtime)
-        except ValueError:  # dateutil.parser.ParserError:
-            print(f"Unable to extract datetime from '{dtime}'. Assuming default Vsw value of {default_vsw} km/s.")
-            return default_vsw
+    try:
+        dtime = parse_time(dtime).datetime  # dateutil.parser.parse(dtime)
+    except ValueError:  # dateutil.parser.ParserError:
+        print(f"Unable to extract datetime from '{dtime}'. Assuming default Vsw value of {default_vsw} km/s.")
+        return default_vsw
 
     try:
         if dataset[body].spz_provider() == 'amda':
@@ -213,7 +212,9 @@ class SolarMACH():
         if coord_sys.lower().startswith('sto') or coord_sys.lower() == "earth":
             coord_sys = 'Stonyhurst'
 
-        self.date = date
+        # parse input date & time
+        self.date = parse_time(date)
+
         self.reference_long = reference_long
         self.reference_lat = reference_lat
         self.coord_sys = coord_sys
@@ -886,7 +887,7 @@ class SolarMACH():
             if self.max_dist < 10:
                 ax.set_rgrids(np.arange(0, self.max_dist + 0.29, 1.0)[1:], angle=rlabel_pos)
 
-        ax.set_title(str(self.date) + ' (UTC)\n', pad=30)
+        ax.set_title(str(self.date.to_value('iso', subfmt='date_hm')) + ' (UTC)\n', pad=30)
 
         plt.tight_layout()
         plt.subplots_adjust(bottom=0.15)
@@ -1024,7 +1025,7 @@ class SolarMACH():
         r_max = r_scaler * 5  # 5 AU = 1075 in units of solar radii
 
         # setting the title
-        ax.set_title(str(self.date) + ' (UTC)\n', pad=30)  # , fontsize=26)
+        ax.set_title(str(self.date.to_value('iso', subfmt='date_hm')) + ' (UTC)\n', pad=30)  # , fontsize=26)
 
         # Plot the source_surface and solar surface
         full_circle_radians = 2*np.pi*np.linspace(0, 1, 200)

--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -144,7 +144,7 @@ def get_sw_speed(body, dtime, trange=1, default_vsw=400.0):
 
     if type(dtime) == str:
         try:
-            dtime = parse_time(dtime)  # dateutil.parser.parse(dtime)
+            dtime = parse_time(dtime).datetime  # dateutil.parser.parse(dtime)
         except ValueError:  # dateutil.parser.ParserError:
             print(f"Unable to extract datetime from '{dtime}'. Assuming default Vsw value of {default_vsw} km/s.")
             return default_vsw

--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -7,7 +7,7 @@ except DistributionNotFound:
     pass  # package is not installed
 
 import copy
-import dateutil.parser  # type: ignore
+# import dateutil.parser  # type: ignore
 import math
 
 import astropy.constants as aconst
@@ -144,8 +144,8 @@ def get_sw_speed(body, dtime, trange=1, default_vsw=400.0):
 
     if type(dtime) == str:
         try:
-            dtime = dateutil.parser.parse(dtime)
-        except dateutil.parser.ParserError:
+            dtime = parse_time(dtime)  # dateutil.parser.parse(dtime)
+        except ValueError:  # dateutil.parser.ParserError:
             print(f"Unable to extract datetime from '{dtime}'. Assuming default Vsw value of {default_vsw} km/s.")
             return default_vsw
 
@@ -661,7 +661,7 @@ class SolarMACH():
                         y_offset_ref = 0.0
                         y_offset_per_i = -0.0475
                     # These offset numbers probably need to be updated; it seems the markers are now too much in the upper left direction.
-                    # They're not visible anymore for test_plotly_legend=[1.0, 1.0], so test for test_plotly_legend=[0.5, 0.5]. 
+                    # They're not visible anymore for test_plotly_legend=[1.0, 1.0], so test for test_plotly_legend=[0.5, 0.5].
                     # Note that the offset effect changes with the size of the plotly figure (i.e., when resizing the browser window)!
                     x_offset = -0.11  # 0.05
                     y_offset = 0.124  # -0.0064

--- a/solarmach/tests/figure_hashes_mpl_353.json
+++ b/solarmach/tests/figure_hashes_mpl_353.json
@@ -1,4 +1,4 @@
 {
-  "solarmach.tests.test.test_solarmach_plot": "79b09259869e749bedcaa5e135896c544e94aca0ee565878c51d491fa1e0fb26",
-  "solarmach.tests.test.test_solarmach_pfss": "e3d893eebb94ed54c98088676e162864f23ed885d6ad46ce5ee6e52957e29184"
+  "solarmach.tests.test.test_solarmach_plot": "0366cb2279a2434ce86a56b929dfa511d0cc4d8294059579a9dbd1d48d331371",
+  "solarmach.tests.test.test_solarmach_pfss": "abe3e9170000a867b1a07b99a4ea1dda621ada68739ada8465b89092b9e45734"
 }

--- a/solarmach/tests/test.py
+++ b/solarmach/tests/test.py
@@ -10,7 +10,7 @@ import pfsspy
 import pytest
 import sunpy
 from pathlib import Path
-from solarmach import SolarMACH, print_body_list, get_gong_map, calculate_pfss_solution, sc_distance
+from solarmach import SolarMACH, print_body_list, get_gong_map, calculate_pfss_solution, sc_distance, get_sw_speed
 
 
 def test_print_body_list():
@@ -20,7 +20,7 @@ def test_print_body_list():
 
 
 def test_solarmach_initialize():
-    body_list = ['STEREO-A']
+    body_list = ['STEREO-A', 'JUICE']
     vsw_list = [400]
     date = '2021-10-28 15:15:00'
     reference_long = 273
@@ -58,6 +58,25 @@ def test_solarmach_get_sw_speed():
         vsw_stereoa = 400.0
     assert np.round(sm.coord_table[sm.coord_table['Spacecraft/Body']=='STEREO-A']['Vsw'].values[0]) == vsw_stereoa
     assert sm.coord_table[sm.coord_table['Spacecraft/Body']=='BepiColombo']['Vsw'].values[0] == 400.0
+
+
+def test_solarmach_wrong_datetime_format():
+    body_list = ['Earth', 'STEREO-A', 'BepiColombo']
+    date = '202110-28 15:15:00'
+    default_vsw = 999.9
+
+    # check only get_sw_speed
+    vsw_earth = get_sw_speed(body_list[0], date, trange=1, default_vsw=default_vsw)
+    assert vsw_earth == default_vsw
+
+    # check only sc_distance
+    distance = sc_distance(body_list[0], body_list[1], date)
+    assert np.isnan(distance.value)
+    assert distance.unit == u.AU
+
+    # check SolarMACH
+    with pytest.raises(ValueError):
+        sm = SolarMACH(date=date, body_list=body_list, coord_sys='Stonyhurst')
 
 
 """


### PR DESCRIPTION
Following https://github.com/jgieseler/solarmach/issues/49:

- Usage of `dateutil.parser.parse()` in `get_sw_speed()` is replaced with `sunpy.time.parse_time().datetime`
- Input datetime to the `SolarMACH` object is directly after initialization send to `sunpy.time.parse_time` and converted to an `astropy.time.Time` object