### PR TITLE
Refactor _isstreamlit() to avoid importing streamlit

### DIFF
--- a/solarmach/__init__.py
+++ b/solarmach/__init__.py
@@ -2886,19 +2886,18 @@ def _isstreamlit():
 
     Returns
     -------
-    use_streamlit : boolean
+    boolean
         True if code is run within streamlit, else False
     """
     # https://discuss.streamlit.io/t/how-to-check-if-code-is-run-inside-streamlit-and-not-e-g-ipython/23439
     try:
+        import sys
+        if "streamlit.runtime.scriptrunner" not in sys.modules:
+            return False
         from streamlit.runtime.scriptrunner import get_script_run_ctx
-        if not get_script_run_ctx(suppress_warning=True):
-            use_streamlit = False
-        else:
-            use_streamlit = True
+        return get_script_run_ctx(suppress_warning=True) is not None
     except ModuleNotFoundError:
-        use_streamlit = False
-    return use_streamlit
+        return False
 
 
 if _isstreamlit():


### PR DESCRIPTION
This pull request refactors the `_isstreamlit` function in `solarmach/__init__.py` to avoid importing streamlit because this changes the plotly theme globally.
* Added a check for `"streamlit.runtime.scriptrunner"` in `sys.modules` before importing, making the detection of Streamlit execution more robust and preventing potential import errors.
* Furthermore, simplified the return logic in `_isstreamlit` to directly return boolean values, reducing unnecessary variables and improving readability.